### PR TITLE
Allow flags without arguments, e.g. "-an" to remove audio

### DIFF
--- a/tasks/responsive_videos.js
+++ b/tasks/responsive_videos.js
@@ -227,14 +227,20 @@ module.exports = function(grunt) {
                         // given settings for this encode
                         _.each(codecSettings, function(codecSetting){
                             for (var key in codecSetting){
-                                flags.push(key,codecSetting[key]);
+                                if (codecSetting[key] == '')
+                                    flags.push(key);
+                                else
+                                    flags.push(key,codecSetting[key]);
                             }
                         });
 
                         // global, encode-independent settings
                         _.each(options.additionalFlags, function(flag){
                             for (var key in flag){
-                                flags.push(key,flag[key]);
+                                if (flags[key] == '')
+                                    flags.push(key);
+                                else
+                                    flags.push(key,flag[key]);
                             }
                         });
 


### PR DESCRIPTION
This allows you to pass in ffmpeg parameters that don't have a value, e.g. you can pass in "-an" with a blank string value to remove audio from the encoded file, e.g.:

```
encodes:[{
            webm: [
             {'-vcodec': 'libvpx'},
             {'-quality': 'good'},
             {'-cpu-used': '0'},
             {'-b:v': '500k'},
             {'-qmax': '42'},
             {'-maxrate': '500k'},
             {'-bufsize': '1000k'},
             {'-threads': '0'},
             {'-an': '' } // Remove audio
            ],
            mp4: [
              {'-vcodec':'libx264'},
              {'-pix_fmt': 'yuv420p'},
              {'-q:v': '4'},
              {'-threads': '0'},
              {'-an': '' } // Remove audio
            ]
          }],
```